### PR TITLE
lower php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"source": "https://github.com/ProfessionalWiki/WikibaseLocalMedia/issues"
 	},
 	"require": {
-		"php": ">=7.3",
+		"php": ">=7.2",
 		"composer/installers": "^1.0.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Hello!

I'm currently trying to add WikibaseLocalMedia to the wikibase docker bundle (https://github.com/wmde/wikibase-release-pipeline/pull/105) but it does not currently compile with master of Mediawiki because of the dependency set to PHP 7.3.

AFAIK master is running tests & installing with composer on PHP 7.2 and REL1_35 is using 7.3

I've tried running the tests locally and they seem to still pass on 7.2