### PR TITLE
Fix compatibility with MediaWiki 1.38

### DIFF
--- a/src/Services/InlineImageFormatter.php
+++ b/src/Services/InlineImageFormatter.php
@@ -99,12 +99,7 @@ class InlineImageFormatter implements ValueFormatter {
 			'height' => 1000
 		];
 
-		if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
-			// MediaWiki 1.34+
-			$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
-		} else {
-			$repoGroup = RepoGroup::singleton();
-		}
+		$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
 
 		$file = $repoGroup->findFile( $fileName );
 		if ( !$file instanceof File ) {

--- a/src/Services/InlineImageFormatter.php
+++ b/src/Services/InlineImageFormatter.php
@@ -10,6 +10,7 @@ use Html;
 use InvalidArgumentException;
 use Language;
 use Linker;
+use MediaWiki\MediaWikiServices;
 use ParserOptions;
 use RepoGroup;
 use Title;
@@ -28,11 +29,6 @@ class InlineImageFormatter implements ValueFormatter {
 	 * @var Language
 	 */
 	private $language;
-
-	/**
-	 * @var RepoGroup
-	 */
-	private $repoGroup;
 
 	/**
 	 * @var ParserOptions
@@ -60,7 +56,6 @@ class InlineImageFormatter implements ValueFormatter {
 	 * @param string $languageCode
 	 * @param ImageLinker $imageLinker
 	 * @param string $captionCssClass
-	 * @param RepoGroup|null $repoGroup
 	 * @throws \MWException
 	 */
 	public function __construct(
@@ -68,11 +63,9 @@ class InlineImageFormatter implements ValueFormatter {
 		array $thumbLimits,
 		string $languageCode,
 		ImageLinker $imageLinker,
-		string $captionCssClass,
-		RepoGroup $repoGroup = null
+		string $captionCssClass
 	) {
 		$this->language = Language::factory( $languageCode );
-		$this->repoGroup = $repoGroup ?: RepoGroup::singleton();
 		$this->parserOptions = $parserOptions;
 		$this->thumbLimits = $thumbLimits;
 		$this->imageLinker = $imageLinker;
@@ -106,7 +99,14 @@ class InlineImageFormatter implements ValueFormatter {
 			'height' => 1000
 		];
 
-		$file = $this->repoGroup->findFile( $fileName );
+		if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
+			// MediaWiki 1.34+
+			$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
+		} else {
+			$repoGroup = RepoGroup::singleton();
+		}
+
+		$file = $repoGroup->findFile( $fileName );
 		if ( !$file instanceof File ) {
 			return $this->getCaptionHtml( $title );
 		}


### PR DESCRIPTION
RepoGroup::singleton was removed on MediaWiki 1.38, deprecated since 1.34.
The InlineImageFormatter::$repoGroup property was only used once, and it was never passed to construct, so removed the property entirely.