### PR TITLE
1.37: Use PropertySpecificComponentsRdfBuilder for OBJECT_PROPERTY

### DIFF
--- a/src/HookHandlers.php
+++ b/src/HookHandlers.php
@@ -22,6 +22,10 @@ final class HookHandlers {
 				return WikibaseLocalMedia::getGlobalInstance()->getRdfBuilder();
 			},
 			'rdf-data-type' => function() {
+				if ( class_exists( 'Wikibase\Repo\Rdf\PropertySpecificComponentsRdfBuilder' ) ) {
+					return \Wikibase\Repo\Rdf\PropertySpecificComponentsRdfBuilder::OBJECT_PROPERTY;
+				}
+
 				if ( class_exists( 'Wikibase\Rdf\PropertyRdfBuilder' ) ) {
 					return \Wikibase\Rdf\PropertyRdfBuilder::OBJECT_PROPERTY;
 				}


### PR DESCRIPTION
Identified while making the 1.37 release of Wikibase.
https://github.com/wmde/wikibase-release-pipeline/pull/357
Details at:
https://github.com/wmde/wikibase-release-pipeline/pull/357#issuecomment-1264678907

The constant moved in 1.37, so usage of it needs to change.
