### PR TITLE
ci-installMediaWiki: use wfLoadExtension for WikibaseRepository

### DIFF
--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -25,10 +25,10 @@ echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
-if [ "$MW_BRANCH" == "REL1_34" ] || [ "$MW_BRANCH" == "REL1_35" ] || [ "$MW_BRANCH" == "REL1_36" ]; then
+if [ "$MW_BRANCH" == "REL1_34" ]; then
   echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
 else
-  echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
+  echo 'wfLoadExtension( "WikibaseRepository", __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
 fi
 
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -23,7 +23,7 @@ echo '$wgDeprecationReleaseLimit = "1.33";' >> LocalSettings.php
 
 echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
-echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
+echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/repo/Wikibase.php" );' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -25,7 +25,7 @@ echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
-if [ "$MW_BRANCH" == "REL1_34" ]; then
+if [ "$MW_BRANCH" == "REL1_34" ] || [ "$MW_BRANCH" == "REL1_35" ]; then
   echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
 else
   echo 'wfLoadExtension( "WikibaseRepository", __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -23,13 +23,14 @@ echo '$wgDeprecationReleaseLimit = "1.33";' >> LocalSettings.php
 
 echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
-echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
 if [ "$MW_BRANCH" == "REL1_34" ] || [ "$MW_BRANCH" == "REL1_35" ]; then
   echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
 else
   echo 'wfLoadExtension( "WikibaseRepository", __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
 fi
+
+echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -23,7 +23,7 @@ echo '$wgDeprecationReleaseLimit = "1.33";' >> LocalSettings.php
 
 echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
-echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/repo/Wikibase.php" );' >> LocalSettings.php
+echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -23,8 +23,13 @@ echo '$wgDeprecationReleaseLimit = "1.33";' >> LocalSettings.php
 
 echo '$wgEnableWikibaseRepo = true;' >> LocalSettings.php
 echo '$wgEnableWikibaseClient = false;' >> LocalSettings.php
-echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
+
+if [ "$MW_BRANCH" == "REL1_34" ] || [ "$MW_BRANCH" == "REL1_35" ] || [ "$MW_BRANCH" == "REL1_36" ]; then
+  echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
+else
+  echo 'wfLoadExtension( 'WikibaseRepository', __DIR__ . "/extensions/Wikibase/extension-repo.json" );' >> LocalSettings.php
+fi
 
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php
 


### PR DESCRIPTION
The PHP entrypoint was deprecated for a while and removed with MediaWiki 1.39.

Fixes #15