### PR TITLE
Use LanguageFactory class to prevent deprecation warning in MediaWiki 1.40

### DIFF
--- a/src/Services/InlineImageFormatter.php
+++ b/src/Services/InlineImageFormatter.php
@@ -65,7 +65,7 @@ class InlineImageFormatter implements ValueFormatter {
 		ImageLinker $imageLinker,
 		string $captionCssClass
 	) {
-		$this->language = Language::factory( $languageCode );
+		$this->language = MediaWikiServices::getInstance()->getContentLanguage();
 		$this->parserOptions = $parserOptions;
 		$this->thumbLimits = $thumbLimits;
 		$this->imageLinker = $imageLinker;


### PR DESCRIPTION
Since MediaWiki 1.35 Language::factory() is deprecated [1]. Since MediaWiki 1.40 this function emits a deprecation warning [2]. This patch uses the new way to access the Language instance.

[1] https://www.mediawiki.org/wiki/Release_notes/1.35
[2] https://www.mediawiki.org/wiki/Release_notes/1.40