### PR TITLE
make suggestion api URL configurable

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,10 +35,15 @@
 
 	"Hooks": {
 		"WikibaseRepoDataTypes": "Wikibase\\LocalMedia\\HookHandlers::onWikibaseRepoDataTypes",
-		"WikibaseClientDataTypes": "Wikibase\\LocalMedia\\HookHandlers::onWikibaseClientDataTypes"
+		"WikibaseClientDataTypes": "Wikibase\\LocalMedia\\HookHandlers::onWikibaseClientDataTypes",
+		"ResourceLoaderGetConfigVars": "Wikibase\\LocalMedia\\HookHandlers::onResourceLoaderGetConfigVars"
 	},
 
 	"config": {
+		"WikibaseLocalMediaRemoteApiUrl": {
+			"value": null,
+			"description": "Optional wiki API URL, works in conjunction with $wgForeignFileRepos for retrieving images from any wiki"
+		}
 	},
 
 	"ResourceFileModulePaths": {

--- a/resources/LocalMediaType.js
+++ b/resources/LocalMediaType.js
@@ -14,9 +14,10 @@ module.exports = ( function( $, vv ) {
 			var notifier = this._viewNotifier,
 				$input = this.$input;
 
+			const apiUrl = mw.config.get( 'wgWikibaseLocalMediaRemoteApiUrl' ) || this._options.vocabularyLookupApiUrl;
 			$input.mediasuggester( {
-				apiUrl: this._options.vocabularyLookupApiUrl,
-				indexPhpUrl: this._options.vocabularyLookupApiUrl.replace('api.php', 'index.php'),
+				apiUrl: apiUrl,
+				indexPhpUrl: apiUrl.replace('api.php', 'index.php'),
 				namespaceId: 6
 			} );
 

--- a/src/HookHandlers.php
+++ b/src/HookHandlers.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Wikibase\LocalMedia;
 
 use ValueFormatters\FormatterOptions;
+use MediaWiki\MediaWikiServices;
 
 final class HookHandlers {
 
@@ -44,4 +45,8 @@ final class HookHandlers {
 		];
 	}
 
+	public static function onResourceLoaderGetConfigVars( array &$vars ): void {
+		$config = MediaWikiServices::getInstance()->getMainConfig();
+		$vars['wgWikibaseLocalMediaRemoteApiUrl'] = $config->get( 'WikibaseLocalMediaRemoteApiUrl' );
+	}
 }


### PR DESCRIPTION
This PR adds a new configuration option to `extension.json` which enables the user to specify a custom wiki API URL. This in conjunction with setting up [$wgForeignFileRepos](https://www.mediawiki.org/wiki/Manual:$wgForeignFileRepos) allows one to use another wikimedia instance as the source for images.

Should address #4 

## Example configuration:
`LocalSettings.php`
```php
$wgForeignFileRepos[] = [
        'class' => ForeignAPIRepo::class,
        'name' => 'factgrid',
        'apibase' => 'https://test.wikipedia.org/w/api.php',
        'hashLevels' => 2,
];
```
`extension.json`
```json
	"config": {
		"WikibaseLocalMediaRemoteApiUrl": {
			"value": "https://test.wikipedia.org/w/api.php",
			"description": "Optional wiki API URL, works in conjunction with $wgForeignFileRepos for retrieving images from any wiki"
		}
	},
```
This will enable use of images from `test.wikipedia.org`