### PR TITLE
Use namespaced version of title

### DIFF
--- a/src/Services/ImageLinkFormatter.php
+++ b/src/Services/ImageLinkFormatter.php
@@ -5,9 +5,9 @@ declare( strict_types = 1 );
 namespace Wikibase\LocalMedia\Services;
 
 use DataValues\StringValue;
-use Html;
+use MediaWiki\Html\Html;
 use InvalidArgumentException;
-use Title;
+use MediaWiki\Title\Title;
 use ValueFormatters\ValueFormatter;
 
 class ImageLinkFormatter implements ValueFormatter {

--- a/src/Services/ImageLinker.php
+++ b/src/Services/ImageLinker.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Wikibase\LocalMedia\Services;
 
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/Services/InlineImageFormatter.php
+++ b/src/Services/InlineImageFormatter.php
@@ -6,13 +6,13 @@ namespace Wikibase\LocalMedia\Services;
 
 use DataValues\StringValue;
 use File;
-use Html;
+use MediaWiki\Html\Html;
 use InvalidArgumentException;
 use Language;
-use Linker;
+use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use ParserOptions;
-use Title;
+use MediaWiki\Title\Title;
 use ValueFormatters\ValueFormatter;
 
 /**

--- a/src/Services/LocalImageLinker.php
+++ b/src/Services/LocalImageLinker.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace Wikibase\LocalMedia\Services;
 
-use Title;
+use MediaWiki\Title\Title;
 
 class LocalImageLinker implements ImageLinker {
 

--- a/src/Services/LocalMediaRdfBuilder.php
+++ b/src/Services/LocalMediaRdfBuilder.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace Wikibase\LocalMedia\Services;
 
 use DataValues\DataValue;
-use TitleFactory;
+use MediaWiki\Title\TitleFactory;
 use Wikibase\Repo\Rdf\Values\ObjectUriRdfBuilder;
 
 class LocalMediaRdfBuilder extends ObjectUriRdfBuilder {

--- a/tests/php/Unit/LocalImageLinkerTest.php
+++ b/tests/php/Unit/LocalImageLinkerTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Wikibase\LocalMedia\Tests\Unit;
 
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use Wikibase\LocalMedia\Services\LocalImageLinker;
 
@@ -15,7 +16,7 @@ use Wikibase\LocalMedia\Services\LocalImageLinker;
 class LocalImageLinkerTest extends TestCase {
 
 	public function testBuildUrlReturnsFullUrl() {
-		$title = \Title::newFromText( 'MyPage' );
+		$title = Title::newFromText( 'MyPage' );
 
 		$this->assertSame(
 			$title->getFullURL(),


### PR DESCRIPTION
* Add one use of namespaced version of Html found as well. Though, this was not checked systematically.

Bug: T166010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal consistency by updating media dependency references to fully qualified namespaces.
- **Tests**
  - Aligned test code with the revised dependency imports for simplified class usage.

These changes improve code clarity and maintainability without affecting any visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->