### PR TITLE
2.0.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 8.0
-            experimental: false
           - mw: 'REL1_40'
-            php: 8.1
+            php: 7.4
             experimental: false
           - mw: 'REL1_41'
-            php: 8.2
+            php: 8.1
             experimental: false
           - mw: 'REL1_42'
             php: 8.2

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Also see [this animated gif](https://twitter.com/i/status/1286293710112731137).
 ## Platform requirements
 
 * [PHP] 7.4 or later
-* [MediaWiki] 1.39 or later
-* [Wikibase Repository] REL1_39 or later
+* [MediaWiki] 1.40 or later
+* [Wikibase Repository]
 
 For more information on the different versions of this extension, see the [release notes](#release-notes).
 
@@ -78,6 +78,14 @@ Example: `https://commons.wikimedia.org/w/api.php`
 * JS tests: `index.php?title=Special%3AJavaScriptTest&filter=jquery.ui.mediasuggester`
 
 ## Release notes
+
+### Version 2.0.0
+
+Released on March 30, 2025
+
+* Raised the minimum MediaWiki version from 1.35 to 1.40
+* Added support for MediaWiki 1.41, 1.42, 1.43, and the development version of 1.44
+* Translation updates
 
 ### Version 1.1.0
 

--- a/extension.json
+++ b/extension.json
@@ -16,7 +16,7 @@
 	"license-name": "GPL-2.0-or-later",
 
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.40.0",
 		"extensions": {
 			"WikibaseRepository": "*"
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,5 +5,7 @@
 
 	<arg name="extensions" value="php"/>
 
-	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
+	</rule>
 </ruleset>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated platform requirements to support MediaWiki 1.40 or later.
  - Added detailed release notes for version 2.0.0, including the release date (March 30, 2025) and expanded compatibility with newer MediaWiki versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->