### PR TITLE
fix: Switch to newFromContext to get parser options

### DIFF
--- a/src/Services/FormatterBuilder.php
+++ b/src/Services/FormatterBuilder.php
@@ -27,7 +27,7 @@ class FormatterBuilder {
 
 		if ( $snakFormat->isPossibleFormat( SnakFormatter::FORMAT_HTML_VERBOSE, $format ) ) {
 			return new InlineImageFormatter(
-				RequestContext::getMain()->getOutput()->parserOptions(),
+				ParserOptions::newFromContext(RequestContext::getMain()->getOutput()),
 				$this->thumbLimits,
 				$options->getOption( ValueFormatter::OPT_LANG ),
 				new LocalImageLinker(),


### PR DESCRIPTION
The old way, `RequestContext::getMain()->getOutput()->parserOptions()`, specifically `parserOptions()`,
was deprecated in MW 1.44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal formatter initialization to use improved parameter handling and configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->