### PR TITLE
Pass language to File::getDimensionsString for MediaWiki 1.47 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -131,7 +131,7 @@ jobs:
             mediawiki
             mediawiki/extensions/
             mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -200,7 +200,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v2
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
           - mw: 'REL1_43'
             php: 8.3
             experimental: false
+          - mw: 'REL1_44'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_45'
+            php: 8.3
+            experimental: false
+          - mw: 'REL1_46'
+            php: 8.4
+            experimental: false
           - mw: 'master'
             php: 8.4
             experimental: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,14 @@ jobs:
         run: composer update
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php extensions/WikibaseLocalMedia/tests/
+        run: |
+          # MediaWiki 1.46 dropped tests/phpunit/phpunit.php in favour of a generated config.
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php extensions/WikibaseLocalMedia/tests/
+          else
+            composer phpunit:config
+            vendor/bin/phpunit extensions/WikibaseLocalMedia/tests/
+          fi
 
   PHPStan:
     name: "PHPStan: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -14,11 +14,10 @@ cd mediawiki
 # Older MediaWiki branches pin such versions; allow them here as this is a throwaway CI install.
 php -r '$f = "composer.json"; $c = json_decode( file_get_contents( $f ), true ); $c["config"]["policy"]["advisories"]["block"] = false; file_put_contents( $f, json_encode( $c, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n" );'
 
-# Wikibase's development branch pulls in beta/dev stability dependencies.
-if [ "$MW_BRANCH" == "master" ]; then
-  composer config minimum-stability dev
-  composer config prefer-stable true
-fi
+# Wikibase's REL1_45 and later branches pull in beta/dev stability dependencies.
+# prefer-stable keeps everything that has a stable release on its stable release.
+composer config minimum-stability dev
+composer config prefer-stable true
 
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -10,6 +10,16 @@ mv mediawiki-$MW_BRANCH mediawiki
 
 cd mediawiki
 
+# Composer 2.10+ refuses to install dependency versions flagged by security advisories.
+# Older MediaWiki branches pin such versions; allow them here as this is a throwaway CI install.
+php -r '$f = "composer.json"; $c = json_decode( file_get_contents( $f ), true ); $c["config"]["policy"]["advisories"]["block"] = false; file_put_contents( $f, json_encode( $c, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n" );'
+
+# Wikibase's development branch pulls in beta/dev stability dependencies.
+if [ "$MW_BRANCH" == "master" ]; then
+  composer config minimum-stability dev
+  composer config prefer-stable true
+fi
+
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -3,10 +3,9 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget "https://github.com/wikimedia/mediawiki/archive/refs/heads/$MW_BRANCH.tar.gz" -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+# Clone rather than download the tarball: since MediaWiki 1.46 the test runner needs
+# phpunit.xml.template, which is marked export-ignore and therefore absent from tarballs.
+git clone --depth=1 --branch="$MW_BRANCH" https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 

--- a/src/Services/InlineImageFormatter.php
+++ b/src/Services/InlineImageFormatter.php
@@ -136,7 +136,8 @@ class InlineImageFormatter implements ValueFormatter {
 
 	private function getFileMetaHtml( File $file ): string {
 		return $this->language->semicolonList( [
-			$file->getDimensionsString(),
+			// @phpstan-ignore arguments.count ($lang required since MW 1.47, ignored on older versions)
+			$file->getDimensionsString( $this->language ),
 			htmlspecialchars( $this->language->formatSize( (int)$file->getSize() ) )
 		] );
 	}

--- a/tests/php/Integration/InlineImageFormatterTest.php
+++ b/tests/php/Integration/InlineImageFormatterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Wikibase\LocalMedia\Tests\Integration;
+
+use DataValues\StringValue;
+use File;
+use MediaWiki\MainConfigNames;
+use MediaWikiIntegrationTestCase;
+use ParserOptions;
+use RepoGroup;
+use Wikibase\LocalMedia\Services\InlineImageFormatter;
+use Wikibase\LocalMedia\Services\LocalImageLinker;
+
+/**
+ * @covers \Wikibase\LocalMedia\Services\InlineImageFormatter
+ */
+class InlineImageFormatterTest extends MediaWikiIntegrationTestCase {
+
+	public function testFileMetadataIncludesDimensions(): void {
+		$this->overrideConfigValue( MainConfigNames::ResponsiveImages, false );
+		$this->setService( 'RepoGroup', $this->newRepoGroupFindingFile() );
+
+		$html = $this->newFormatter()->format( new StringValue( 'Jonas-revenge.png' ) );
+
+		$this->assertStringContainsString( '800 × 600 pixels', $html );
+	}
+
+	private function newRepoGroupFindingFile(): RepoGroup {
+		$file = $this->createStub( File::class );
+		$file->method( 'transform' )->willReturn( $this->newThumbnail() );
+		$file->method( 'getDimensionsString' )->willReturn( '800 × 600 pixels' );
+		$file->method( 'getSize' )->willReturn( 12345 );
+
+		$repoGroup = $this->createStub( RepoGroup::class );
+		$repoGroup->method( 'findFile' )->willReturn( $file );
+
+		return $repoGroup;
+	}
+
+	private function newThumbnail(): object {
+		return new class {
+			public function toHtml(): string {
+				return '<img src="thumbnail.png">';
+			}
+		};
+	}
+
+	private function newFormatter(): InlineImageFormatter {
+		return new InlineImageFormatter(
+			ParserOptions::newFromAnon(),
+			[],
+			'en',
+			new LocalImageLinker(),
+			'commons-media-caption'
+		);
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/WikibaseLocalMedia/issues/47

`File::getDimensionsString()` gained a required `$lang` parameter in MediaWiki 1.47 (optional since 1.46), so calling it without arguments threw an `ArgumentCountError` when rendering local media values. Passing the content language works across the whole supported range: it is harmlessly ignored on 1.45 and earlier, satisfies the optional parameter on 1.46, and the required one on 1.47+.

The existing formatting tests format a non-existent file and never reach the metadata path. `InlineImageFormatterTest` stubs `RepoGroup` to return a file, exercising `getDimensionsString` so a regression is caught on versions where the parameter is required.

CI: add REL1_44/45/46 to the matrix, and repair it so it runs again across the whole range:

- disable Composer 2.10's security-advisory blocking (older branches pin flagged dependency versions);
- allow dev/beta stability (Wikibase REL1_45+ pulls in a beta dependency);
- clone MediaWiki instead of downloading the tarball, which omits the export-ignored `phpunit.xml.template` that 1.46+ needs, and use the generated PHPUnit config on 1.46+.

The full matrix from 1.40 through master is green, so the fix is verified on MediaWiki master, where the parameter is required.

---

_Written by Claude Code, Opus 4.8. Result of back-and-forth with @JeroenDeDauw, including his decision to take the comprehensive CI route. Context: the WikibaseLocalMedia codebase, MediaWiki core source from REL1_43 through master, the extension's GitHub Actions CI, and web research on the `getDimensionsString` signature change and Composer 2.10's advisory blocking._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
