### PR TITLE
Release version 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Example: `https://commons.wikimedia.org/w/api.php`
 
 Released on June 12, 2026
 
-* Added support for MediaWiki 1.44, 1.45, 1.46, and 1.47
+* Added support for MediaWiki 1.44, 1.45, and 1.46
 * Translation updates
 
 ### Version 2.0.0

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Example: `https://commons.wikimedia.org/w/api.php`
 
 ## Release notes
 
+### Version 2.0.1
+
+Released on June 12, 2026
+
+* Added support for MediaWiki 1.44, 1.45, 1.46, and 1.47
+* Translation updates
+
 ### Version 2.0.0
 
 Released on March 30, 2025

--- a/extension.json
+++ b/extension.json
@@ -2,7 +2,7 @@
 	"name": "Wikibase Local Media",
 	"type": "wikibase",
 
-	"version": "2.0.0",
+	"version": "2.0.1",
 
 	"author": [
 		"[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]",


### PR DESCRIPTION
Prepares the 2.0.1 release: bumps the version and adds release notes.

2.0.1 adds support for MediaWiki 1.44, 1.45, and 1.46, plus translation updates. The underlying compatibility fix from #48 also resolves the MediaWiki 1.47 `ArgumentCountError` (https://github.com/ProfessionalWiki/WikibaseLocalMedia/issues/47), but 1.47 is still in development so it is not advertised in the release notes.

The release date in the notes is today's date as a placeholder — adjust it when tagging. No tag has been created.

---

_Written by Claude Code, Opus 4.8, at @JeroenDeDauw's request. Context: the WikibaseLocalMedia codebase and its README release-notes convention, following the just-merged #48._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
