### PR TITLE
Fix MW 1.47 compatibility: OutputPage::parserOptions() was removed

### DIFF
--- a/src/Services/FormatterBuilder.php
+++ b/src/Services/FormatterBuilder.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Wikibase\LocalMedia\Services;
 
+use ParserOptions;
 use RequestContext;
 use ValueFormatters\FormatterOptions;
 use ValueFormatters\ValueFormatter;
@@ -27,7 +28,7 @@ class FormatterBuilder {
 
 		if ( $snakFormat->isPossibleFormat( SnakFormatter::FORMAT_HTML_VERBOSE, $format ) ) {
 			return new InlineImageFormatter(
-				RequestContext::getMain()->getOutput()->parserOptions(),
+				ParserOptions::newFromContext( RequestContext::getMain() ),
 				$this->thumbLimits,
 				$options->getOption( ValueFormatter::OPT_LANG ),
 				new LocalImageLinker(),


### PR DESCRIPTION
OutputPage::parserOptions() was removed in MediaWiki core (wikimedia/mediawiki@3772013). FormatterBuilder still called it, causing FormattingTest::testHtmlFormat to fail on MW master and item pages with localMedia statements to fatal on MW 1.47.

Use ParserOptions::newFromContext() instead, which is available in all supported MediaWiki versions.

Fixes #50

Same approach as #46 by @a-random-lemurian.

**Verification:**
- `FormattingTest::testHtmlFormat` fails on MW master without this change
  ([failing run](https://github.com/MaRDI4NFDI/WikibaseLocalMedia/actions/runs/29404175064/job/87315524058))
  and passes with it ([CI on this PR](https://github.com/ProfessionalWiki/WikibaseLocalMedia/actions/runs/29496380616/job/87615765131?pr=51), all 8 MW versions green)
- Deployed and confirmed in MaRDI Portal staging (MediaWiki 1.47.0-wmf.10) via MaRDI4NFDI/docker-wikibase#334 -
  item pages with localMedia statements render correctly again.